### PR TITLE
Add Art Museum to Open Source Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1400,6 +1400,7 @@ Open source React Native apps and other examples.
 * [Hydropuzzle](https://github.com/hydropuzzle/hydropuzzle) - Stylish puzzle adventure game.
 * [Github-Gist](https://github.com/Arjun-sna/react-native-githubgist-client) - React native mobile application for github gist
 * [Lyrics King](https://github.com/SKempin/Lyrics-King-React-Native) - Minimalist and stylish lyrics search app.
+* [Art Museum](https://github.com/pedrobern/react-native-art-museums-app) - Browse through the endless Harvard's Art Museum collection.
 
 ## Frameworks
 


### PR DESCRIPTION
[Source code](https://github.com/PedroBern/react-native-art-museums-app)

[Google Play link](https://play.google.com/store/apps/details?id=museum.art&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1)

This app use [Harvard Art Museum API](https://github.com/harvardartmuseums/api-docs) to let you browse through the art collection.


